### PR TITLE
Added .codecov.yml to support monorepo like structure to report cover…

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,9 +11,9 @@ coverage:
         target: 70%
         flags: python-toolbox
 flags:
-  projectA:
+  engine-executor:
     paths:
     - engine-executor/src
-  projectB:
+  python-toolbox:
     paths:
     - python-toolbox/marvin_python_toolbox

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -16,4 +16,4 @@ flags:
     - engine-executor
   python-toolbox:
     paths:
-    - python-toolbox/marvin_python_toolbox
+    - python-toolbox

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,19 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 70%
+        threshold: null
+      engine-executor:
+        flags: engine-executor
+        target: 50%
+      python-toolbox:
+        target: 70%
+        flags: python-toolbox
+flags:
+  projectA:
+    paths:
+    - engine-executor/src
+  projectB:
+    paths:
+    - python-toolbox/marvin_python_toolbox

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,7 +13,7 @@ coverage:
 flags:
   engine-executor:
     paths:
-    - engine-executor/src
+    - engine-executor
   python-toolbox:
     paths:
     - python-toolbox/marvin_python_toolbox

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ matrix:
         - cd engine-executor
         - unset SBT_OPTS
       script: travis_retry sbt -batch ++$TRAVIS_SCALA_VERSION coverage test coverageReport
+      after_success:
+      - bash <(curl -s https://codecov.io/bash)
     # Python Toolbox
     # Python Toolbox - Linux
     - language: python


### PR DESCRIPTION
Added .codecov.yml based on the flag support for https://docs.codecov.io/docs/flags. I have validated the configuration but cant test it with the original repo as I dont have the repo token : 

### Validation Output: 

```
➜  incubator-marvin git:(MARVIN-43) ✗ curl --data-binary @.codecov.yml https://codecov.io/validate
Valid!

{
  "flags": {
    "projectA": {
      "paths": [
        "^engine-executor/src.*"
      ]
    },
    "projectB": {
      "paths": [
        "^python-toolbox/marvin_python_toolbox.*"
      ]
    }
  },
  "coverage": {
    "status": {
      "project": {
        "default": {
          "threshold": null,
          "target": 70.0
        },
        "engine-executor": {
          "flags": [
            "engine-executor"
          ],
          "target": 50.0
        },
        "python-toolbox": {
          "flags": [
            "python-toolbox"
          ],
          "target": 70.0
        }
      }
    }
  }
}
```

Could the repo owners help with testing the configuration