### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -54,23 +54,23 @@ RUN mkdir -p $MARVIN_HOME && \
 ##############################################################
 
 RUN apt-get update -y && \
-    apt-get install -y build-essential && \
-    apt-get install -y maven git cmake software-properties-common curl libstdc++6 && \
-    apt-get install -y wget && \
-    apt-get install -y libffi-dev && \
-    apt-get install -y libssl-dev && \
-    apt-get install -y libxml2-dev && \
-    apt-get install -y libxslt1-dev && \
-    apt-get install -y libpng12-dev && \
-    apt-get install -y libfreetype6-dev && \
-    apt-get install -y libsasl2-dev && \
-    apt-get install -y graphviz && \
+    apt-get --no-install-recommends install -y build-essential && \
+    apt-get --no-install-recommends install -y maven git cmake software-properties-common curl libstdc++6 && \
+    apt-get --no-install-recommends install -y wget && \
+    apt-get --no-install-recommends install -y libffi-dev && \
+    apt-get --no-install-recommends install -y libssl-dev && \
+    apt-get --no-install-recommends install -y libxml2-dev && \
+    apt-get --no-install-recommends install -y libxslt1-dev && \
+    apt-get --no-install-recommends install -y libpng12-dev && \
+    apt-get --no-install-recommends install -y libfreetype6-dev && \
+    apt-get --no-install-recommends install -y libsasl2-dev && \
+    apt-get --no-install-recommends install -y graphviz && \
     apt-get clean
 
 ### Installs Open JDK 8
 RUN add-apt-repository ppa:openjdk-r/ppa && \
     apt-get update && \
-    apt-get install -y openjdk-8-jdk
+    apt-get --no-install-recommends install -y openjdk-8-jdk
 
 ## TODO - Think in a good way to make Spark an option as soon we implement docker supporting it
 ##############################################################

--- a/build/docker-python/Dockerfile
+++ b/build/docker-python/Dockerfile
@@ -26,13 +26,13 @@ ENV WORKON_HOME=$MARVIN_HOME/.virtualenvs
 ##############################################################
 
 RUN apt-get update -y && \
-    apt-get install -y python && \
-    apt-get install -y python2.7-dev && \
-    apt-get install -y python-pip && \
-    apt-get install -y ipython && \
-    # ??? apt-get install -y python-tk && \ ??? #
+    apt-get --no-install-recommends install -y python && \
+    apt-get --no-install-recommends install -y python2.7-dev && \
+    apt-get --no-install-recommends install -y python-pip && \
+    apt-get --no-install-recommends install -y ipython && \
+    # ??? apt-get --no-install-recommends install -y python-tk && \ ??? #
     pip install --upgrade pip==9.0.1 && \
-    apt install -y libzmq3-dev libcurl4-openssl-dev libssl-dev && \
+    apt-get --no-install-recommends install -y libzmq3-dev libcurl4-openssl-dev libssl-dev && \
     pip install jupyter && \
     apt-get clean
 

--- a/build/docker-r/Dockerfile
+++ b/build/docker-r/Dockerfile
@@ -25,17 +25,17 @@ FROM marvin-base:${BASE_TAG}
 # Install the system dependencies for default R installation 
 ##############################################################
 
-RUN apt install -y apt-transport-https &&\
+RUN apt-get --no-install-recommends install -y apt-transport-https &&\
     apt update && \
-    apt install -y python2.7-dev && \
-    apt install -y python-pip && \
-    apt install -y ipython && \
+    apt-get --no-install-recommends install -y python2.7-dev && \
+    apt-get --no-install-recommends install -y python-pip && \
+    apt-get --no-install-recommends install -y ipython && \
     pip install --upgrade pip==9.0.1 && \
-    apt install -y libzmq3-dev libcurl4-openssl-dev libssl-dev && \
+    apt-get --no-install-recommends install -y libzmq3-dev libcurl4-openssl-dev libssl-dev && \
     pip install jupyter
     
 
-RUN apt install -y r-base && \
+RUN apt-get --no-install-recommends install -y r-base && \
     su -c "R -e \"install.packages(c('repr', 'IRdisplay', 'IRkernel'), type = 'source', repos='http://cran.rstudio.com/')\"" && \
     su -c "R -e \"IRkernel::installspec(user = FALSE)\""
 

--- a/public-engines/iris-automl/fabfile.py
+++ b/public-engines/iris-automl/fabfile.py
@@ -34,7 +34,7 @@ def install_oracle_jdk():
     sudo("apt-get -qq update")
     run("echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections")
     run("echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections")
-    sudo("apt-get install -y oracle-java8-installer")
+    sudo("apt-get --no-install-recommends install -y oracle-java8-installer")
 
 
 def install_virtualenvwrapper():
@@ -52,21 +52,21 @@ def install_apache_spark():
 
 def install_required_packages():
     sudo("apt-get update -y")
-    sudo("apt-get install -y git")
-    sudo("apt-get install -y wget")
-    sudo("apt-get install -y python2.7-dev")
-    sudo("apt-get install -y python-pip")
-    sudo("apt-get install -y ipython")
-    sudo("apt-get install -y libffi-dev")
-    sudo("apt-get install -y libssl-dev")
-    sudo("apt-get install -y libxml2-dev")
-    sudo("apt-get install -y libxslt1-dev")
-    sudo("apt-get install -y libpng12-dev")
-    sudo("apt-get install -y libfreetype6-dev")
-    sudo("apt-get install -y python-tk")
-    sudo("apt-get install -y libsasl2-dev")
-    sudo("apt-get install -y python-pip")
-    sudo("apt-get install -y graphviz")
+    sudo("apt-get --no-install-recommends install -y git")
+    sudo("apt-get --no-install-recommends install -y wget")
+    sudo("apt-get --no-install-recommends install -y python2.7-dev")
+    sudo("apt-get --no-install-recommends install -y python-pip")
+    sudo("apt-get --no-install-recommends install -y ipython")
+    sudo("apt-get --no-install-recommends install -y libffi-dev")
+    sudo("apt-get --no-install-recommends install -y libssl-dev")
+    sudo("apt-get --no-install-recommends install -y libxml2-dev")
+    sudo("apt-get --no-install-recommends install -y libxslt1-dev")
+    sudo("apt-get --no-install-recommends install -y libpng12-dev")
+    sudo("apt-get --no-install-recommends install -y libfreetype6-dev")
+    sudo("apt-get --no-install-recommends install -y python-tk")
+    sudo("apt-get --no-install-recommends install -y libsasl2-dev")
+    sudo("apt-get --no-install-recommends install -y python-pip")
+    sudo("apt-get --no-install-recommends install -y graphviz")
     sudo("pip install --upgrade pip")
 
 

--- a/public-engines/iris-h2o-automl/fabfile.py
+++ b/public-engines/iris-h2o-automl/fabfile.py
@@ -34,7 +34,7 @@ def install_oracle_jdk():
     sudo("apt-get -qq update")
     run("echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections")
     run("echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections")
-    sudo("apt-get install -y oracle-java8-installer")
+    sudo("apt-get --no-install-recommends install -y oracle-java8-installer")
 
 
 def install_virtualenvwrapper():
@@ -52,21 +52,21 @@ def install_apache_spark():
 
 def install_required_packages():
     sudo("apt-get update -y")
-    sudo("apt-get install -y git")
-    sudo("apt-get install -y wget")
-    sudo("apt-get install -y python2.7-dev")
-    sudo("apt-get install -y python-pip")
-    sudo("apt-get install -y ipython")
-    sudo("apt-get install -y libffi-dev")
-    sudo("apt-get install -y libssl-dev")
-    sudo("apt-get install -y libxml2-dev")
-    sudo("apt-get install -y libxslt1-dev")
-    sudo("apt-get install -y libpng12-dev")
-    sudo("apt-get install -y libfreetype6-dev")
-    sudo("apt-get install -y python-tk")
-    sudo("apt-get install -y libsasl2-dev")
-    sudo("apt-get install -y python-pip")
-    sudo("apt-get install -y graphviz")
+    sudo("apt-get --no-install-recommends install -y git")
+    sudo("apt-get --no-install-recommends install -y wget")
+    sudo("apt-get --no-install-recommends install -y python2.7-dev")
+    sudo("apt-get --no-install-recommends install -y python-pip")
+    sudo("apt-get --no-install-recommends install -y ipython")
+    sudo("apt-get --no-install-recommends install -y libffi-dev")
+    sudo("apt-get --no-install-recommends install -y libssl-dev")
+    sudo("apt-get --no-install-recommends install -y libxml2-dev")
+    sudo("apt-get --no-install-recommends install -y libxslt1-dev")
+    sudo("apt-get --no-install-recommends install -y libpng12-dev")
+    sudo("apt-get --no-install-recommends install -y libfreetype6-dev")
+    sudo("apt-get --no-install-recommends install -y python-tk")
+    sudo("apt-get --no-install-recommends install -y libsasl2-dev")
+    sudo("apt-get --no-install-recommends install -y python-pip")
+    sudo("apt-get --no-install-recommends install -y graphviz")
     sudo("pip install --upgrade pip")
 
 

--- a/public-engines/kaggle-titanic-engine/Dockerfile
+++ b/public-engines/kaggle-titanic-engine/Dockerfile
@@ -38,23 +38,23 @@ RUN mkdir -p $MARVIN_HOME && \
 ##############################################################
 
 RUN apt-get update -y && \
-    apt-get install -y build-essential && \
-    apt-get install -y maven git python cmake software-properties-common curl libstdc++6 && \
-    apt-get install -y git && \
-    apt-get install -y wget && \
-    apt-get install -y python2.7-dev && \
-    apt-get install -y python-pip && \
-    apt-get install -y ipython && \
-    apt-get install -y libffi-dev && \
-    apt-get install -y libssl-dev && \
-    apt-get install -y libxml2-dev && \
-    apt-get install -y libxslt1-dev && \
-    apt-get install -y libpng12-dev && \
-    apt-get install -y libfreetype6-dev && \
-    apt-get install -y python-tk && \
-    apt-get install -y libsasl2-dev && \
-    apt-get install -y python-pip && \
-    apt-get install -y graphviz && \
+    apt-get --no-install-recommends install -y build-essential && \
+    apt-get --no-install-recommends install -y maven git python cmake software-properties-common curl libstdc++6 && \
+    apt-get --no-install-recommends install -y git && \
+    apt-get --no-install-recommends install -y wget && \
+    apt-get --no-install-recommends install -y python2.7-dev && \
+    apt-get --no-install-recommends install -y python-pip && \
+    apt-get --no-install-recommends install -y ipython && \
+    apt-get --no-install-recommends install -y libffi-dev && \
+    apt-get --no-install-recommends install -y libssl-dev && \
+    apt-get --no-install-recommends install -y libxml2-dev && \
+    apt-get --no-install-recommends install -y libxslt1-dev && \
+    apt-get --no-install-recommends install -y libpng12-dev && \
+    apt-get --no-install-recommends install -y libfreetype6-dev && \
+    apt-get --no-install-recommends install -y python-tk && \
+    apt-get --no-install-recommends install -y libsasl2-dev && \
+    apt-get --no-install-recommends install -y python-pip && \
+    apt-get --no-install-recommends install -y graphviz && \
     pip install --upgrade pip && \
     apt-get clean
 
@@ -65,7 +65,7 @@ RUN add-apt-repository ppa:webupd8team/java -y && \
     apt-get -qq update && \
     echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
     echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections && \
-    apt-get install -y oracle-java8-installer    
+    apt-get --no-install-recommends install -y oracle-java8-installer    
 
 
 ##############################################################

--- a/public-engines/kaggle-titanic-engine/fabfile.py
+++ b/public-engines/kaggle-titanic-engine/fabfile.py
@@ -34,7 +34,7 @@ def install_oracle_jdk():
     sudo("apt-get -qq update")
     run("echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections")
     run("echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections")
-    sudo("apt-get install -y oracle-java8-installer")
+    sudo("apt-get --no-install-recommends install -y oracle-java8-installer")
 
 
 def install_virtualenvwrapper():
@@ -52,21 +52,21 @@ def install_apache_spark():
 
 def install_required_packages():
     sudo("apt-get update -y")
-    sudo("apt-get install -y git")
-    sudo("apt-get install -y wget")
-    sudo("apt-get install -y python2.7-dev")
-    sudo("apt-get install -y python-pip")
-    sudo("apt-get install -y ipython")
-    sudo("apt-get install -y libffi-dev")
-    sudo("apt-get install -y libssl-dev")
-    sudo("apt-get install -y libxml2-dev")
-    sudo("apt-get install -y libxslt1-dev")
-    sudo("apt-get install -y libpng12-dev")
-    sudo("apt-get install -y libfreetype6-dev")
-    sudo("apt-get install -y python-tk")
-    sudo("apt-get install -y libsasl2-dev")
-    sudo("apt-get install -y python-pip")
-    sudo("apt-get install -y graphviz")
+    sudo("apt-get --no-install-recommends install -y git")
+    sudo("apt-get --no-install-recommends install -y wget")
+    sudo("apt-get --no-install-recommends install -y python2.7-dev")
+    sudo("apt-get --no-install-recommends install -y python-pip")
+    sudo("apt-get --no-install-recommends install -y ipython")
+    sudo("apt-get --no-install-recommends install -y libffi-dev")
+    sudo("apt-get --no-install-recommends install -y libssl-dev")
+    sudo("apt-get --no-install-recommends install -y libxml2-dev")
+    sudo("apt-get --no-install-recommends install -y libxslt1-dev")
+    sudo("apt-get --no-install-recommends install -y libpng12-dev")
+    sudo("apt-get --no-install-recommends install -y libfreetype6-dev")
+    sudo("apt-get --no-install-recommends install -y python-tk")
+    sudo("apt-get --no-install-recommends install -y libsasl2-dev")
+    sudo("apt-get --no-install-recommends install -y python-pip")
+    sudo("apt-get --no-install-recommends install -y graphviz")
     sudo("pip install --upgrade pip")
 
 

--- a/public-engines/mnist-keras-engine/Dockerfile
+++ b/public-engines/mnist-keras-engine/Dockerfile
@@ -37,23 +37,23 @@ RUN mkdir -p $MARVIN_HOME && \
 ##############################################################
 
 RUN apt-get update -y && \
-    apt-get install -y build-essential && \
-    apt-get install -y maven git python cmake software-properties-common curl libstdc++6 && \
-    apt-get install -y git && \
-    apt-get install -y wget && \
-    apt-get install -y python2.7-dev && \
-    apt-get install -y python-pip && \
-    apt-get install -y ipython && \
-    apt-get install -y libffi-dev && \
-    apt-get install -y libssl-dev && \
-    apt-get install -y libxml2-dev && \
-    apt-get install -y libxslt1-dev && \
-    apt-get install -y libpng12-dev && \
-    apt-get install -y libfreetype6-dev && \
-    apt-get install -y python-tk && \
-    apt-get install -y libsasl2-dev && \
-    apt-get install -y python-pip && \
-    apt-get install -y graphviz && \
+    apt-get --no-install-recommends install -y build-essential && \
+    apt-get --no-install-recommends install -y maven git python cmake software-properties-common curl libstdc++6 && \
+    apt-get --no-install-recommends install -y git && \
+    apt-get --no-install-recommends install -y wget && \
+    apt-get --no-install-recommends install -y python2.7-dev && \
+    apt-get --no-install-recommends install -y python-pip && \
+    apt-get --no-install-recommends install -y ipython && \
+    apt-get --no-install-recommends install -y libffi-dev && \
+    apt-get --no-install-recommends install -y libssl-dev && \
+    apt-get --no-install-recommends install -y libxml2-dev && \
+    apt-get --no-install-recommends install -y libxslt1-dev && \
+    apt-get --no-install-recommends install -y libpng12-dev && \
+    apt-get --no-install-recommends install -y libfreetype6-dev && \
+    apt-get --no-install-recommends install -y python-tk && \
+    apt-get --no-install-recommends install -y libsasl2-dev && \
+    apt-get --no-install-recommends install -y python-pip && \
+    apt-get --no-install-recommends install -y graphviz && \
     pip install --upgrade pip && \
     apt-get clean
 
@@ -64,7 +64,7 @@ RUN add-apt-repository ppa:webupd8team/java -y && \
     apt-get -qq update && \
     echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
     echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections && \
-    apt-get install -y oracle-java8-installer    
+    apt-get --no-install-recommends install -y oracle-java8-installer    
 
 
 ##############################################################

--- a/public-engines/mnist-keras-engine/fabfile.py
+++ b/public-engines/mnist-keras-engine/fabfile.py
@@ -34,7 +34,7 @@ def install_oracle_jdk():
     sudo("apt-get -qq update")
     run("echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections")
     run("echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections")
-    sudo("apt-get install -y oracle-java8-installer")
+    sudo("apt-get --no-install-recommends install -y oracle-java8-installer")
 
 
 def install_virtualenvwrapper():
@@ -52,21 +52,21 @@ def install_apache_spark():
 
 def install_required_packages():
     sudo("apt-get update -y")
-    sudo("apt-get install -y git")
-    sudo("apt-get install -y wget")
-    sudo("apt-get install -y python2.7-dev")
-    sudo("apt-get install -y python-pip")
-    sudo("apt-get install -y ipython")
-    sudo("apt-get install -y libffi-dev")
-    sudo("apt-get install -y libssl-dev")
-    sudo("apt-get install -y libxml2-dev")
-    sudo("apt-get install -y libxslt1-dev")
-    sudo("apt-get install -y libpng12-dev")
-    sudo("apt-get install -y libfreetype6-dev")
-    sudo("apt-get install -y python-tk")
-    sudo("apt-get install -y libsasl2-dev")
-    sudo("apt-get install -y python-pip")
-    sudo("apt-get install -y graphviz")
+    sudo("apt-get --no-install-recommends install -y git")
+    sudo("apt-get --no-install-recommends install -y wget")
+    sudo("apt-get --no-install-recommends install -y python2.7-dev")
+    sudo("apt-get --no-install-recommends install -y python-pip")
+    sudo("apt-get --no-install-recommends install -y ipython")
+    sudo("apt-get --no-install-recommends install -y libffi-dev")
+    sudo("apt-get --no-install-recommends install -y libssl-dev")
+    sudo("apt-get --no-install-recommends install -y libxml2-dev")
+    sudo("apt-get --no-install-recommends install -y libxslt1-dev")
+    sudo("apt-get --no-install-recommends install -y libpng12-dev")
+    sudo("apt-get --no-install-recommends install -y libfreetype6-dev")
+    sudo("apt-get --no-install-recommends install -y python-tk")
+    sudo("apt-get --no-install-recommends install -y libsasl2-dev")
+    sudo("apt-get --no-install-recommends install -y python-pip")
+    sudo("apt-get --no-install-recommends install -y graphviz")
     sudo("pip install --upgrade pip")
 
 

--- a/public-engines/nlp-ner-engine/Dockerfile
+++ b/public-engines/nlp-ner-engine/Dockerfile
@@ -37,23 +37,23 @@ RUN mkdir -p $MARVIN_HOME && \
 ##############################################################
 
 RUN apt-get update -y && \
-    apt-get install -y build-essential && \
-    apt-get install -y maven git python cmake software-properties-common curl libstdc++6 && \
-    apt-get install -y git && \
-    apt-get install -y wget && \
-    apt-get install -y python2.7-dev && \
-    apt-get install -y python-pip && \
-    apt-get install -y ipython && \
-    apt-get install -y libffi-dev && \
-    apt-get install -y libssl-dev && \
-    apt-get install -y libxml2-dev && \
-    apt-get install -y libxslt1-dev && \
-    apt-get install -y libpng12-dev && \
-    apt-get install -y libfreetype6-dev && \
-    apt-get install -y python-tk && \
-    apt-get install -y libsasl2-dev && \
-    apt-get install -y python-pip && \
-    apt-get install -y graphviz && \
+    apt-get --no-install-recommends install -y build-essential && \
+    apt-get --no-install-recommends install -y maven git python cmake software-properties-common curl libstdc++6 && \
+    apt-get --no-install-recommends install -y git && \
+    apt-get --no-install-recommends install -y wget && \
+    apt-get --no-install-recommends install -y python2.7-dev && \
+    apt-get --no-install-recommends install -y python-pip && \
+    apt-get --no-install-recommends install -y ipython && \
+    apt-get --no-install-recommends install -y libffi-dev && \
+    apt-get --no-install-recommends install -y libssl-dev && \
+    apt-get --no-install-recommends install -y libxml2-dev && \
+    apt-get --no-install-recommends install -y libxslt1-dev && \
+    apt-get --no-install-recommends install -y libpng12-dev && \
+    apt-get --no-install-recommends install -y libfreetype6-dev && \
+    apt-get --no-install-recommends install -y python-tk && \
+    apt-get --no-install-recommends install -y libsasl2-dev && \
+    apt-get --no-install-recommends install -y python-pip && \
+    apt-get --no-install-recommends install -y graphviz && \
     pip install --upgrade pip && \
     apt-get clean
 
@@ -64,7 +64,7 @@ RUN add-apt-repository ppa:webupd8team/java -y && \
     apt-get -qq update && \
     echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
     echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections && \
-    apt-get install -y oracle-java8-installer    
+    apt-get --no-install-recommends install -y oracle-java8-installer    
 
 
 ##############################################################

--- a/public-engines/nlp-ner-engine/fabfile.py
+++ b/public-engines/nlp-ner-engine/fabfile.py
@@ -34,7 +34,7 @@ def install_oracle_jdk():
     sudo("apt-get -qq update")
     run("echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections")
     run("echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections")
-    sudo("apt-get install -y oracle-java8-installer")
+    sudo("apt-get --no-install-recommends install -y oracle-java8-installer")
 
 
 def install_virtualenvwrapper():
@@ -52,21 +52,21 @@ def install_apache_spark():
 
 def install_required_packages():
     sudo("apt-get update -y")
-    sudo("apt-get install -y git")
-    sudo("apt-get install -y wget")
-    sudo("apt-get install -y python2.7-dev")
-    sudo("apt-get install -y python-pip")
-    sudo("apt-get install -y ipython")
-    sudo("apt-get install -y libffi-dev")
-    sudo("apt-get install -y libssl-dev")
-    sudo("apt-get install -y libxml2-dev")
-    sudo("apt-get install -y libxslt1-dev")
-    sudo("apt-get install -y libpng12-dev")
-    sudo("apt-get install -y libfreetype6-dev")
-    sudo("apt-get install -y python-tk")
-    sudo("apt-get install -y libsasl2-dev")
-    sudo("apt-get install -y python-pip")
-    sudo("apt-get install -y graphviz")
+    sudo("apt-get --no-install-recommends install -y git")
+    sudo("apt-get --no-install-recommends install -y wget")
+    sudo("apt-get --no-install-recommends install -y python2.7-dev")
+    sudo("apt-get --no-install-recommends install -y python-pip")
+    sudo("apt-get --no-install-recommends install -y ipython")
+    sudo("apt-get --no-install-recommends install -y libffi-dev")
+    sudo("apt-get --no-install-recommends install -y libssl-dev")
+    sudo("apt-get --no-install-recommends install -y libxml2-dev")
+    sudo("apt-get --no-install-recommends install -y libxslt1-dev")
+    sudo("apt-get --no-install-recommends install -y libpng12-dev")
+    sudo("apt-get --no-install-recommends install -y libfreetype6-dev")
+    sudo("apt-get --no-install-recommends install -y python-tk")
+    sudo("apt-get --no-install-recommends install -y libsasl2-dev")
+    sudo("apt-get --no-install-recommends install -y python-pip")
+    sudo("apt-get --no-install-recommends install -y graphviz")
     sudo("pip install --upgrade pip")
 
 

--- a/public-engines/product-classifier-engine/Dockerfile
+++ b/public-engines/product-classifier-engine/Dockerfile
@@ -37,23 +37,23 @@ RUN mkdir -p $MARVIN_HOME && \
 ##############################################################
 
 RUN apt-get update -y && \
-    apt-get install -y build-essential && \
-    apt-get install -y maven git python cmake software-properties-common curl libstdc++6 && \
-    apt-get install -y git && \
-    apt-get install -y wget && \
-    apt-get install -y python2.7-dev && \
-    apt-get install -y python-pip && \
-    apt-get install -y ipython && \
-    apt-get install -y libffi-dev && \
-    apt-get install -y libssl-dev && \
-    apt-get install -y libxml2-dev && \
-    apt-get install -y libxslt1-dev && \
-    apt-get install -y libpng12-dev && \
-    apt-get install -y libfreetype6-dev && \
-    apt-get install -y python-tk && \
-    apt-get install -y libsasl2-dev && \
-    apt-get install -y python-pip && \
-    apt-get install -y graphviz && \
+    apt-get --no-install-recommends install -y build-essential && \
+    apt-get --no-install-recommends install -y maven git python cmake software-properties-common curl libstdc++6 && \
+    apt-get --no-install-recommends install -y git && \
+    apt-get --no-install-recommends install -y wget && \
+    apt-get --no-install-recommends install -y python2.7-dev && \
+    apt-get --no-install-recommends install -y python-pip && \
+    apt-get --no-install-recommends install -y ipython && \
+    apt-get --no-install-recommends install -y libffi-dev && \
+    apt-get --no-install-recommends install -y libssl-dev && \
+    apt-get --no-install-recommends install -y libxml2-dev && \
+    apt-get --no-install-recommends install -y libxslt1-dev && \
+    apt-get --no-install-recommends install -y libpng12-dev && \
+    apt-get --no-install-recommends install -y libfreetype6-dev && \
+    apt-get --no-install-recommends install -y python-tk && \
+    apt-get --no-install-recommends install -y libsasl2-dev && \
+    apt-get --no-install-recommends install -y python-pip && \
+    apt-get --no-install-recommends install -y graphviz && \
     pip install --upgrade pip && \
     apt-get clean
 
@@ -64,7 +64,7 @@ RUN add-apt-repository ppa:webupd8team/java -y && \
     apt-get -qq update && \
     echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
     echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections && \
-    apt-get install -y oracle-java8-installer    
+    apt-get --no-install-recommends install -y oracle-java8-installer    
 
 
 ##############################################################

--- a/public-engines/product-classifier-engine/fabfile.py
+++ b/public-engines/product-classifier-engine/fabfile.py
@@ -34,7 +34,7 @@ def install_oracle_jdk():
     sudo("apt-get -qq update")
     run("echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections")
     run("echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections")
-    sudo("apt-get install -y oracle-java8-installer")
+    sudo("apt-get --no-install-recommends install -y oracle-java8-installer")
 
 
 def install_virtualenvwrapper():
@@ -52,21 +52,21 @@ def install_apache_spark():
 
 def install_required_packages():
     sudo("apt-get update -y")
-    sudo("apt-get install -y git")
-    sudo("apt-get install -y wget")
-    sudo("apt-get install -y python2.7-dev")
-    sudo("apt-get install -y python-pip")
-    sudo("apt-get install -y ipython")
-    sudo("apt-get install -y libffi-dev")
-    sudo("apt-get install -y libssl-dev")
-    sudo("apt-get install -y libxml2-dev")
-    sudo("apt-get install -y libxslt1-dev")
-    sudo("apt-get install -y libpng12-dev")
-    sudo("apt-get install -y libfreetype6-dev")
-    sudo("apt-get install -y python-tk")
-    sudo("apt-get install -y libsasl2-dev")
-    sudo("apt-get install -y python-pip")
-    sudo("apt-get install -y graphviz")
+    sudo("apt-get --no-install-recommends install -y git")
+    sudo("apt-get --no-install-recommends install -y wget")
+    sudo("apt-get --no-install-recommends install -y python2.7-dev")
+    sudo("apt-get --no-install-recommends install -y python-pip")
+    sudo("apt-get --no-install-recommends install -y ipython")
+    sudo("apt-get --no-install-recommends install -y libffi-dev")
+    sudo("apt-get --no-install-recommends install -y libssl-dev")
+    sudo("apt-get --no-install-recommends install -y libxml2-dev")
+    sudo("apt-get --no-install-recommends install -y libxslt1-dev")
+    sudo("apt-get --no-install-recommends install -y libpng12-dev")
+    sudo("apt-get --no-install-recommends install -y libfreetype6-dev")
+    sudo("apt-get --no-install-recommends install -y python-tk")
+    sudo("apt-get --no-install-recommends install -y libsasl2-dev")
+    sudo("apt-get --no-install-recommends install -y python-pip")
+    sudo("apt-get --no-install-recommends install -y graphviz")
     sudo("pip install --upgrade pip")
 
 

--- a/public-engines/sms-spam-engine/Dockerfile
+++ b/public-engines/sms-spam-engine/Dockerfile
@@ -37,23 +37,23 @@ RUN mkdir -p $MARVIN_HOME && \
 ##############################################################
 
 RUN apt-get update -y && \
-    apt-get install -y build-essential && \
-    apt-get install -y maven git python cmake software-properties-common curl libstdc++6 && \
-    apt-get install -y git && \
-    apt-get install -y wget && \
-    apt-get install -y python2.7-dev && \
-    apt-get install -y python-pip && \
-    apt-get install -y ipython && \
-    apt-get install -y libffi-dev && \
-    apt-get install -y libssl-dev && \
-    apt-get install -y libxml2-dev && \
-    apt-get install -y libxslt1-dev && \
-    apt-get install -y libpng12-dev && \
-    apt-get install -y libfreetype6-dev && \
-    apt-get install -y python-tk && \
-    apt-get install -y libsasl2-dev && \
-    apt-get install -y python-pip && \
-    apt-get install -y graphviz && \
+    apt-get --no-install-recommends install -y build-essential && \
+    apt-get --no-install-recommends install -y maven git python cmake software-properties-common curl libstdc++6 && \
+    apt-get --no-install-recommends install -y git && \
+    apt-get --no-install-recommends install -y wget && \
+    apt-get --no-install-recommends install -y python2.7-dev && \
+    apt-get --no-install-recommends install -y python-pip && \
+    apt-get --no-install-recommends install -y ipython && \
+    apt-get --no-install-recommends install -y libffi-dev && \
+    apt-get --no-install-recommends install -y libssl-dev && \
+    apt-get --no-install-recommends install -y libxml2-dev && \
+    apt-get --no-install-recommends install -y libxslt1-dev && \
+    apt-get --no-install-recommends install -y libpng12-dev && \
+    apt-get --no-install-recommends install -y libfreetype6-dev && \
+    apt-get --no-install-recommends install -y python-tk && \
+    apt-get --no-install-recommends install -y libsasl2-dev && \
+    apt-get --no-install-recommends install -y python-pip && \
+    apt-get --no-install-recommends install -y graphviz && \
     pip install --upgrade pip && \
     apt-get clean
 
@@ -64,7 +64,7 @@ RUN add-apt-repository ppa:webupd8team/java -y && \
     apt-get -qq update && \
     echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
     echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections && \
-    apt-get install -y oracle-java8-installer    
+    apt-get --no-install-recommends install -y oracle-java8-installer    
 
 
 ##############################################################

--- a/public-engines/sms-spam-engine/fabfile.py
+++ b/public-engines/sms-spam-engine/fabfile.py
@@ -34,7 +34,7 @@ def install_oracle_jdk():
     sudo("apt-get -qq update")
     run("echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections")
     run("echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections")
-    sudo("apt-get install -y oracle-java8-installer")
+    sudo("apt-get --no-install-recommends install -y oracle-java8-installer")
 
 
 def install_virtualenvwrapper():
@@ -52,21 +52,21 @@ def install_apache_spark():
 
 def install_required_packages():
     sudo("apt-get update -y")
-    sudo("apt-get install -y git")
-    sudo("apt-get install -y wget")
-    sudo("apt-get install -y python2.7-dev")
-    sudo("apt-get install -y python-pip")
-    sudo("apt-get install -y ipython")
-    sudo("apt-get install -y libffi-dev")
-    sudo("apt-get install -y libssl-dev")
-    sudo("apt-get install -y libxml2-dev")
-    sudo("apt-get install -y libxslt1-dev")
-    sudo("apt-get install -y libpng12-dev")
-    sudo("apt-get install -y libfreetype6-dev")
-    sudo("apt-get install -y python-tk")
-    sudo("apt-get install -y libsasl2-dev")
-    sudo("apt-get install -y python-pip")
-    sudo("apt-get install -y graphviz")
+    sudo("apt-get --no-install-recommends install -y git")
+    sudo("apt-get --no-install-recommends install -y wget")
+    sudo("apt-get --no-install-recommends install -y python2.7-dev")
+    sudo("apt-get --no-install-recommends install -y python-pip")
+    sudo("apt-get --no-install-recommends install -y ipython")
+    sudo("apt-get --no-install-recommends install -y libffi-dev")
+    sudo("apt-get --no-install-recommends install -y libssl-dev")
+    sudo("apt-get --no-install-recommends install -y libxml2-dev")
+    sudo("apt-get --no-install-recommends install -y libxslt1-dev")
+    sudo("apt-get --no-install-recommends install -y libpng12-dev")
+    sudo("apt-get --no-install-recommends install -y libfreetype6-dev")
+    sudo("apt-get --no-install-recommends install -y python-tk")
+    sudo("apt-get --no-install-recommends install -y libsasl2-dev")
+    sudo("apt-get --no-install-recommends install -y python-pip")
+    sudo("apt-get --no-install-recommends install -y graphviz")
     sudo("pip install --upgrade pip")
 
 


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>