### PR TITLE
fix thrift-sasl to version 0.3.0

### DIFF
--- a/python-toolbox/setup.py
+++ b/python-toolbox/setup.py
@@ -58,7 +58,7 @@ REQUIREMENTS_EXTERNAL = [
     'paramiko>=2.1.2',
     'PyHive>=0.3.0',
     'thrift>=0.10.0',
-    'thrift-sasl>=0.2.1',
+    'thrift-sasl==0.3.0',
     'virtualenvwrapper>=4.7.1',
     'requests>=2.19.1',
     'python-dateutil>=2.7.3',


### PR DESCRIPTION
https://github.com/apache/incubator-marvin/pull/44
is failing because of thrift-sasl-0.4.1 require thrift-0.9.3
since we have other dependencies that require thrift-0.10.0 or above, I will downgrade thrift-sasl to version 0.3.0