### PR TITLE
Change log level from toolbox to INFO

### DIFF
--- a/python-toolbox/marvin_python_toolbox/_logging.py
+++ b/python-toolbox/marvin_python_toolbox/_logging.py
@@ -24,7 +24,7 @@ import os
 import os.path
 import logging
 
-DEFAULT_LOG_LEVEL = logging.WARNING
+DEFAULT_LOG_LEVEL = logging.INFO
 DEFAULT_LOG_DIR = '/tmp'
 
 

--- a/python-toolbox/marvin_python_toolbox/management/templates/python-engine/project_package/_logging.py
+++ b/python-toolbox/marvin_python_toolbox/management/templates/python-engine/project_package/_logging.py
@@ -11,7 +11,7 @@ import os
 import os.path
 import logging
 
-DEFAULT_LOG_LEVEL = logging.WARNING
+DEFAULT_LOG_LEVEL = logging.INFO
 DEFAULT_LOG_DIR = '/tmp'
 
 


### PR DESCRIPTION
Since we don't have WARNING logs, I changed the log level to make it more useful. We can replace some print lines for log lines further.