### PR TITLE
Update Spark Dependency Path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
       python:
         - 3.6
       before_install:
-        - travis_retry curl https://d3kbcqa49mib13.cloudfront.net/spark-2.1.1-bin-hadoop2.6.tgz -o ./spark-2.1.1-bin-hadoop2.6.tgz
+        - travis_retry curl https://archive.apache.org/dist/spark/spark-2.1.1/spark-2.1.1-bin-hadoop2.6.tgz -o ./spark-2.1.1-bin-hadoop2.6.tgz
         - sudo tar -xf ./spark-2.1.1-bin-hadoop2.6.tgz
         - cd python-daemon
         - mkdir -p marvin_data
@@ -67,7 +67,7 @@ matrix:
       python:
         - 3.6
       before_install:
-        - travis_retry curl https://d3kbcqa49mib13.cloudfront.net/spark-2.1.1-bin-hadoop2.6.tgz -o ./spark-2.1.1-bin-hadoop2.6.tgz
+        - travis_retry curl https://archive.apache.org/dist/spark/spark-2.1.1/spark-2.1.1-bin-hadoop2.6.tgz -o ./spark-2.1.1-bin-hadoop2.6.tgz
         - sudo tar -xf ./spark-2.1.1-bin-hadoop2.6.tgz
         - cd python-toolbox
         - mkdir -p marvin_data


### PR DESCRIPTION
Based on #65 testing error, update the spark path, as the original path is no longer valid.
Checked the [Apache archive](https://archive.apache.org/dist/spark/spark-2.1.1/) with the new link.