### PR TITLE
Update Travis-CI Badge Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ limitations under the License.
 
 Branch | Status | CodeCov
 -|-|-
-[master](https://github.com/apache/incubator-marvin/tree/master) | [![Build Status](https://travis-ci.org/apache/incubator-marvin.svg?branch=master)](https://travis-ci.org/apache/incubator-marvin) | [![Codecov](https://codecov.io/gh/apache/incubator-marvin/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/incubator-marvin)
-[develop](https://github.com/apache/incubator-marvin/tree/develop) | [![Build Status](https://travis-ci.org/apache/incubator-marvin.svg?branch=develop)](https://travis-ci.org/apache/incubator-marvin/branches) | [![Build Status](https://codecov.io/gh/apache/incubator-marvin/branch/develop/graph/badge.svg)](https://codecov.io/gh/apache/incubator-marvin/branch/develop)
+[master](https://github.com/apache/incubator-marvin/tree/master) | [![Build Status](https://app.travis-ci.com/apache/incubator-marvin.svg?branch=master)](https://app.travis-ci.com/apache/incubator-marvin) | [![Codecov](https://codecov.io/gh/apache/incubator-marvin/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/incubator-marvin)
+[develop](https://github.com/apache/incubator-marvin/tree/develop) | [![Build Status](https://app.travis-ci.com/apache/incubator-marvin.svg?branch=develop)](https://app.travis-ci.com/apache/incubator-marvin) | [![CodeCov](https://codecov.io/gh/apache/incubator-marvin/branch/develop/graph/badge.svg)](https://codecov.io/gh/apache/incubator-marvin/branch/develop)
 
 **Marvin** is an open-source Artificial Intelligence platform that focuses on helping data scientists deliver meaningful solutions to complex problems. Supported by a standardized large-scale, language-agnostic architecture, Marvin simplifies the process of exploration and modeling.
 

--- a/engine-executor/README.md
+++ b/engine-executor/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/apache/incubator-marvin.svg)](https://travis-ci.org/apache/incubator-marvin) [![codecov](https://codecov.io/gh/apache/incubator-marvin/branch/develop/graph/badge.svg)](https://codecov.io/gh/apache/incubator-marvin/branch/develop)
+[![Build Status](https://app.travis-ci.com/apache/incubator-marvin.svg)](https://app.travis-ci.com/apache/incubator-marvin) [![codecov](https://codecov.io/gh/apache/incubator-marvin/branch/develop/graph/badge.svg)](https://codecov.io/gh/apache/incubator-marvin/branch/develop)
 
 # Marvin Engine Executor (Server)
 


### PR DESCRIPTION
The Travis-CI had updated their domain years ago. We need to update the badge link to the correct address.